### PR TITLE
remove dtypes

### DIFF
--- a/src/fast_array_utils/_patches.py
+++ b/src/fast_array_utils/_patches.py
@@ -6,7 +6,7 @@ import numpy as np
 
 # TODO(flying-sheep): upstream
 # https://github.com/dask/dask/issues/11749
-def patch_dask() -> None:
+def patch_dask() -> None:  # pragma: no cover
     """Patch dask to support sparse arrays.
 
     See <https://github.com/dask/dask/blob/4d71629d1f22ced0dd780919f22e70a642ec6753/dask/array/backends.py#L212-L232>

--- a/src/fast_array_utils/conv/_asarray.py
+++ b/src/fast_array_utils/conv/_asarray.py
@@ -10,11 +10,9 @@ from ..types import CSBase, CupyArray, CupySparseMatrix, DaskArray, H5Dataset, O
 
 
 if TYPE_CHECKING:
-    from typing import Any, TypeVar
+    from typing import Any
 
     from numpy.typing import ArrayLike, NDArray
-
-    DT_co = TypeVar("DT_co", covariant=True, bound=np.generic)
 
 
 __all__ = ["OutOfCoreDataset", "asarray"]
@@ -22,7 +20,7 @@ __all__ = ["OutOfCoreDataset", "asarray"]
 
 # fallback’s arg0 type has to include types of registered functions
 @singledispatch
-def asarray(x: ArrayLike | CSBase[DT_co] | OutOfCoreDataset[DT_co]) -> NDArray[DT_co]:
+def asarray(x: ArrayLike | CSBase | OutOfCoreDataset[Any]) -> NDArray[Any]:
     """Convert x to a numpy array.
 
     Parameters
@@ -39,19 +37,19 @@ def asarray(x: ArrayLike | CSBase[DT_co] | OutOfCoreDataset[DT_co]) -> NDArray[D
 
 
 @asarray.register(CSBase)  # type: ignore[call-overload,misc]
-def _(x: CSBase[DT_co]) -> NDArray[DT_co]:
+def _(x: CSBase) -> NDArray[Any]:
     from .scipy import to_dense
 
     return to_dense(x)
 
 
 @asarray.register(DaskArray)
-def _(x: DaskArray) -> NDArray[DT_co]:
+def _(x: DaskArray) -> NDArray[Any]:
     return asarray(x.compute())  # type: ignore[no-untyped-call]
 
 
 @asarray.register(OutOfCoreDataset)
-def _(x: OutOfCoreDataset[CSBase[DT_co] | NDArray[DT_co]]) -> NDArray[DT_co]:
+def _(x: OutOfCoreDataset[CSBase | NDArray[Any]]) -> NDArray[Any]:
     return asarray(x.to_memory())
 
 

--- a/src/fast_array_utils/conv/scipy/_to_dense.py
+++ b/src/fast_array_utils/conv/scipy/_to_dense.py
@@ -8,20 +8,17 @@ import numpy as np
 
 
 if TYPE_CHECKING:
-    from typing import Literal, TypeVar
+    from typing import Any, Literal
 
     from numpy.typing import NDArray
 
     from ...types import CSBase
 
-    DT_co = TypeVar("DT_co", bound=np.generic, covariant=True)
-    DT = TypeVar("DT", bound=np.generic)
-
 
 __all__ = ["to_dense"]
 
 
-def to_dense(x: CSBase[DT_co], order: Literal["C", "F"] = "C") -> NDArray[DT_co]:
+def to_dense(x: CSBase, order: Literal["C", "F"] = "C") -> NDArray[Any]:
     """Convert a compressed sparse matrix to a dense matrix.
 
     Parameters
@@ -48,10 +45,10 @@ def to_dense(x: CSBase[DT_co], order: Literal["C", "F"] = "C") -> NDArray[DT_co]
 
 @numba.njit(cache=True)
 def _to_dense_csc_numba(
-    indptr: NDArray[DT],
-    indices: NDArray[DT],
-    data: NDArray[DT_co],
-    x: NDArray[DT_co],
+    indptr: NDArray[np.integer[Any]],
+    indices: NDArray[np.integer[Any]],
+    data: NDArray[np.number[Any]],
+    x: NDArray[np.number[Any]],
 ) -> None:
     for c in numba.prange(x.shape[1]):
         for i in range(indptr[c], indptr[c + 1]):
@@ -60,10 +57,10 @@ def _to_dense_csc_numba(
 
 @numba.njit(cache=True)
 def _to_dense_csr_numba(
-    indptr: NDArray[DT],
-    indices: NDArray[DT],
-    data: NDArray[DT_co],
-    x: NDArray[DT_co],
+    indptr: NDArray[np.integer[Any]],
+    indices: NDArray[np.integer[Any]],
+    data: NDArray[np.number[Any]],
+    x: NDArray[np.number[Any]],
 ) -> None:
     for r in numba.prange(x.shape[0]):
         for i in range(indptr[r], indptr[r + 1]):

--- a/src/fast_array_utils/stats/_sum.py
+++ b/src/fast_array_utils/stats/_sum.py
@@ -49,7 +49,7 @@ def _(
     else:
         from dask.array import reduction
 
-    if isinstance(x._meta, np.matrix):  # noqa: SLF001
+    if isinstance(x._meta, np.matrix):  # pragma: no cover  # noqa: SLF001
         msg = "sum does not support numpy matrices"
         raise TypeError(msg)
 
@@ -66,7 +66,7 @@ def _(
                 axis = n
             case (0, 1) | (1, 0):
                 axis = None
-            case tuple():
+            case tuple():  # pragma: no cover
                 msg = f"`sum` can only sum over `axis=0|1|(0,1)` but got {axis} instead"
                 raise ValueError(msg)
         rv: NDArray[Any] | np.number[Any] = sum(a, axis=axis, dtype=dtype)  # type: ignore[arg-type]

--- a/src/fast_array_utils/types.py
+++ b/src/fast_array_utils/types.py
@@ -32,14 +32,14 @@ else:
         from scipy.sparse import csc_array, csr_array
 
         CSArray = csr_array | csc_array
-    except ImportError:
+    except ImportError:  # pragma: no cover
         CSArray = type("CSArray", (), {})
 
     try:  # cs?_matrix is available when scipy is installed
         from scipy.sparse import csc_matrix, csr_matrix
 
         CSMatrix = csr_matrix | csc_matrix
-    except ImportError:
+    except ImportError:  # pragma: no cover
         CSMatrix = type("CSMatrix", (), {})
 
     CSBase = CSMatrix | CSArray
@@ -47,13 +47,13 @@ else:
 
 if TYPE_CHECKING or find_spec("cupy"):
     from cupy import ndarray as CupyArray
-else:
+else:  # pragma: no cover
     CupyArray = type("ndarray", (), {})
 
 
 if TYPE_CHECKING or find_spec("cupyx"):
     from cupyx.scipy.sparse import spmatrix as CupySparseMatrix
-else:
+else:  # pragma: no cover
     CupySparseMatrix = type("spmatrix", (), {})
 
 
@@ -61,19 +61,19 @@ if TYPE_CHECKING:  # https://github.com/dask/dask/issues/8853
     from dask.array.core import Array as DaskArray
 elif find_spec("dask"):
     from dask.array import Array as DaskArray
-else:
+else:  # pragma: no cover
     DaskArray = type("array", (), {})
 
 
 if TYPE_CHECKING or find_spec("h5py"):
     from h5py import Dataset as H5Dataset
-else:
+else:  # pragma: no cover
     H5Dataset = type("Dataset", (), {})
 
 
 if TYPE_CHECKING or find_spec("zarr"):
     from zarr import Array as ZarrArray
-else:
+else:  # pragma: no cover
     ZarrArray = type("Array", (), {})
 
 

--- a/src/fast_array_utils/types.py
+++ b/src/fast_array_utils/types.py
@@ -7,12 +7,6 @@ from importlib.util import find_spec
 from typing import TYPE_CHECKING, Generic, Protocol, TypeVar, runtime_checkable
 
 
-if TYPE_CHECKING:
-    from typing import Any, TypeAlias
-
-    import numpy as np
-
-
 __all__ = [
     "CSBase",
     "CupyArray",
@@ -30,11 +24,9 @@ T_co = TypeVar("T_co", covariant=True)
 if TYPE_CHECKING:
     from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
 
-    _SCT_co = TypeVar("_SCT_co", covariant=True, bound=np.generic)
-
-    CSArray: TypeAlias = csr_array[Any, np.dtype[_SCT_co]] | csc_array[Any, np.dtype[_SCT_co]]
-    CSMatrix: TypeAlias = csr_matrix[Any, np.dtype[_SCT_co]] | csc_matrix[Any, np.dtype[_SCT_co]]
-    CSBase: TypeAlias = CSMatrix[_SCT_co] | CSArray[_SCT_co]
+    CSArray = csr_array | csc_array
+    CSMatrix = csr_matrix | csc_matrix
+    CSBase = CSMatrix | CSArray
 else:
     try:  # cs?_array isn’t available in older scipy versions
         from scipy.sparse import csc_array, csr_array

--- a/src/testing/fast_array_utils/__init__.py
+++ b/src/testing/fast_array_utils/__init__.py
@@ -10,38 +10,37 @@ import numpy as np
 
 
 if TYPE_CHECKING:
-    from typing import Any, Generic, Literal, Protocol, SupportsFloat, TypeAlias, TypeVar
+    from typing import Any, Literal, Protocol, SupportsFloat, TypeAlias
 
-    from numpy.typing import ArrayLike, NDArray
+    from numpy.typing import ArrayLike, DTypeLike, NDArray
 
     from fast_array_utils import types
     from fast_array_utils.types import CSBase
 
-    _SCT_co = TypeVar("_SCT_co", covariant=True, bound=np.generic)
-    _SCT_contra = TypeVar("_SCT_contra", contravariant=True, bound=np.generic)
-    _SCT_float = TypeVar("_SCT_float", np.float32, np.float64)
-
     Array: TypeAlias = (
-        NDArray[_SCT_co]
-        | types.CSBase[_SCT_co]
-        | types.CupyArray[_SCT_co]
+        NDArray[Any]
+        | types.CSBase
+        | types.CupyArray
         | types.DaskArray
         | types.H5Dataset
         | types.ZarrArray
     )
 
-    class ToArray(Protocol, Generic[_SCT_contra]):
+    class ToArray(Protocol):
         """Convert to a supported array."""
 
         def __call__(  # noqa: D102
-            self, data: ArrayLike, /, *, dtype: _SCT_contra | None = None
-        ) -> Array[_SCT_contra]: ...
+            self, data: ArrayLike, /, *, dtype: DTypeLike | None = None
+        ) -> Array: ...
+
+    _DTypeLikeFloat32 = np.dtype[np.float32] | type[np.float32]
+    _DTypeLikeFloat64 = np.dtype[np.float64] | type[np.float64]
 
 
 RE_ARRAY_QUAL = re.compile(r"(?P<mod>(?:\w+\.)*\w+)\.(?P<name>[^\[]+)(?:\[(?P<inner>[\w.]+)\])?")
 
 
-def get_array_cls(qualname: str) -> type[Array[Any]]:  # noqa: PLR0911
+def get_array_cls(qualname: str) -> type[Array]:  # noqa: PLR0911
     """Get a supported array class by qualname."""
     m = RE_ARRAY_QUAL.fullmatch(qualname)
     assert m
@@ -87,10 +86,10 @@ def random_mat(
     *,
     density: SupportsFloat = 0.01,
     format: Literal["csr", "csc"] = "csr",  # noqa: A002
-    dtype: np.dtype[_SCT_float] | type[_SCT_float] | None = None,
+    dtype: DTypeLike | None = None,
     container: Literal["array", "matrix"] = "array",
     gen: np.random.Generator | None = None,
-) -> CSBase[_SCT_float]:
+) -> CSBase:
     """Create a random matrix."""
     from scipy.sparse import random as random_spmat
     from scipy.sparse import random_array as random_sparr
@@ -107,9 +106,9 @@ def random_array(
     qualname: str,
     shape: tuple[int, int],
     *,
-    dtype: np.dtype[_SCT_float] | type[_SCT_float] | None,
+    dtype: _DTypeLikeFloat32 | _DTypeLikeFloat64 | None,
     gen: np.random.Generator | None = None,
-) -> Array[_SCT_float]:
+) -> Array:
     """Create a random array."""
     gen = np.random.default_rng(gen)
 

--- a/src/testing/fast_array_utils/pytest.py
+++ b/src/testing/fast_array_utils/pytest.py
@@ -17,15 +17,12 @@ from . import get_array_cls
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from typing import Any, TypeVar
 
     from numpy.typing import ArrayLike, DTypeLike
 
     from testing.fast_array_utils import ToArray
 
     from . import Array
-
-    _SCT_co = TypeVar("_SCT_co", covariant=True, bound=np.generic)
 
 
 def _skip_if_no(dist: str) -> pytest.MarkDecorator:
@@ -58,24 +55,24 @@ def array_cls_name(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="session")
-def array_cls(array_cls_name: str) -> type[Array[Any]]:
+def array_cls(array_cls_name: str) -> type[Array]:
     """Fixture for a supported array class."""
     return get_array_cls(array_cls_name)
 
 
 @pytest.fixture(scope="session")
 def to_array(
-    request: pytest.FixtureRequest, array_cls: type[Array[_SCT_co]], array_cls_name: str
-) -> ToArray[_SCT_co]:
+    request: pytest.FixtureRequest, array_cls: type[Array], array_cls_name: str
+) -> ToArray:
     """Fixture for conversion into a supported array."""
     return get_to_array(array_cls, array_cls_name, request)
 
 
 def get_to_array(
-    array_cls: type[Array[_SCT_co]],
+    array_cls: type[Array],
     array_cls_name: str | None = None,
     request: pytest.FixtureRequest | None = None,
-) -> ToArray[_SCT_co]:
+) -> ToArray:
     """Create a function to convert to a supported array."""
     if array_cls is np.ndarray:
         return np.asarray  # type: ignore[return-value]
@@ -103,7 +100,7 @@ def _half_chunk_size(a: tuple[int, ...]) -> tuple[int, ...]:
     return tuple(half_rounded_up(x) for x in a)
 
 
-def to_dask_array(array_cls_name: str) -> ToArray[Any]:
+def to_dask_array(array_cls_name: str) -> ToArray:
     """Convert to a dask array."""
     if TYPE_CHECKING:
         import dask.array.core as da
@@ -112,7 +109,7 @@ def to_dask_array(array_cls_name: str) -> ToArray[Any]:
 
     inner_cls_name = array_cls_name.removeprefix("dask.array.Array[").removesuffix("]")
     inner_cls = get_array_cls(inner_cls_name)
-    to_array_fn: ToArray[Any] = get_to_array(array_cls=inner_cls)
+    to_array_fn: ToArray = get_to_array(array_cls=inner_cls)
 
     def to_dask_array(x: ArrayLike, *, dtype: DTypeLike | None = None) -> types.DaskArray:
         x = np.asarray(x, dtype=dtype)
@@ -126,7 +123,7 @@ def to_dask_array(array_cls_name: str) -> ToArray[Any]:
 def to_h5py_dataset(
     tmp_path_factory: pytest.TempPathFactory,
     worker_id: str = "serial",
-) -> Generator[ToArray[Any], None, None]:
+) -> Generator[ToArray, None, None]:
     """Convert to a h5py dataset."""
     import h5py
 

--- a/tests/test_asarray.py
+++ b/tests/test_asarray.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from testing.fast_array_utils import ToArray
 
 
-def test_asarray(to_array: ToArray[Any]) -> None:
+def test_asarray(to_array: ToArray) -> None:
     x = to_array([[1, 2, 3], [4, 5, 6]])
     arr: NDArray[Any] = asarray(x)  # type: ignore[arg-type]
     assert isinstance(arr, np.ndarray)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -12,12 +12,10 @@ from testing.fast_array_utils import random_mat
 
 
 if TYPE_CHECKING:
-    from typing import Literal, TypeVar
+    from typing import Literal
 
+    from numpy.typing import DTypeLike
     from pytest_codspeed import BenchmarkFixture
-
-    DType = TypeVar("DType", bound=np.generic)
-    DType_float = TypeVar("DType_float", np.float32, np.float64)
 
 
 pytestmark = [pytest.mark.skipif(not find_spec("scipy"), reason="scipy not installed")]
@@ -34,15 +32,15 @@ def sp_container(request: pytest.FixtureRequest) -> Literal["array", "matrix"]:
 
 
 @pytest.fixture(scope="session", params=[np.float32, np.float64])
-def dtype(request: pytest.FixtureRequest) -> np.dtype[np.float32 | np.float64]:
-    return np.dtype(request.param)
+def dtype(request: pytest.FixtureRequest) -> type[np.float32 | np.float64]:
+    return request.param  # type: ignore[no-any-return]
 
 
 @pytest.mark.parametrize("order", ["C", "F"])
 def test_to_dense(
     order: Literal["C", "F"],
     sp_fmt: Literal["csr", "csc"],
-    dtype: np.dtype[DType_float],
+    dtype: DTypeLike,
     sp_container: Literal["array", "matrix"],
 ) -> None:
     mat = random_mat((10, 10), density=0.1, format=sp_fmt, dtype=dtype, container=sp_container)
@@ -58,7 +56,7 @@ def test_to_dense_benchmark(
     benchmark: BenchmarkFixture,
     order: Literal["C", "F"],
     sp_fmt: Literal["csr", "csc"],
-    dtype: np.dtype[DType_float],
+    dtype: DTypeLike,
 ) -> None:
     mat = random_mat((1_000, 1_000), format=sp_fmt, dtype=dtype, container="array")
     to_dense(mat, order=order)  # warmup: numba compile

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -45,8 +45,8 @@ def dtype_arg(request: pytest.FixtureRequest) -> DTypeOut | None:
 
 
 def test_sum(
-    array_cls: type[Array[Any]],
-    to_array: ToArray[Any],
+    array_cls: type[Array],
+    to_array: ToArray,
     dtype_in: DTypeIn,
     dtype_arg: DTypeOut | None,
     axis: Literal[0, 1, None],
@@ -92,7 +92,7 @@ def test_sum_benchmark(
 ) -> None:
     try:
         shape = (1_000, 1_000) if "sparse" in array_cls_name else (100, 100)
-        arr = random_array(array_cls_name, shape, dtype=dtype)  # type: ignore  # noqa: PGH003
+        arr = random_array(array_cls_name, shape, dtype=dtype)
     except NotImplementedError:
         pytest.skip("random_array not implemented for dtype")
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -10,17 +10,13 @@ from fast_array_utils import types
 
 
 if TYPE_CHECKING:
-    from typing import TypeVar
+    from numpy.typing import DTypeLike
 
     from testing.fast_array_utils import Array, ToArray
 
-    DType_float = TypeVar("DType_float", np.float32, np.float64)
-
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_conv(
-    array_cls: type[Array[DType_float]], to_array: ToArray[DType_float], dtype: DType_float
-) -> None:
+def test_conv(array_cls: type[Array], to_array: ToArray, dtype: DTypeLike) -> None:
     arr = to_array(np.arange(12).reshape(3, 4), dtype=dtype)
     assert isinstance(arr, array_cls)
     if isinstance(arr, types.DaskArray):


### PR DESCRIPTION
It’s really hard to do this right, and PyRight was struggling hard, making development painful.

Also it might be impossible to have items that are both valid arguments to `isinstance` and generic types.