### PR TITLE
parametrize benchmarks, skip matrix

### DIFF
--- a/src/testing/fast_array_utils/__init__.py
+++ b/src/testing/fast_array_utils/__init__.py
@@ -26,13 +26,11 @@ __all__ = [
 _TP_MEM = (
     ArrayType("numpy", "ndarray", Flags.Any),
     ArrayType("cupy", "ndarray", Flags.Any | Flags.Gpu),
+    *(ArrayType("scipy.sparse", n, Flags.Any | Flags.Sparse) for n in ["csr_array", "csc_array"]),
     *(
-        ArrayType("scipy.sparse", n, Flags.Any | Flags.Sparse)
-        for n in ["csr_array", "csc_array", "csr_matrix", "csc_matrix"]
-    ),
-    *(
-        ArrayType("cupyx.scipy.sparse", n, Flags.Any | Flags.Gpu | Flags.Sparse)
+        ArrayType(mod, n, Flags.Any | Flags.Sparse | Flags.Matrix | flags)
         for n in ["csr_matrix", "csc_matrix"]
+        for (mod, flags) in [("scipy.sparse", Flags(0)), ("cupyx.scipy.sparse", Flags.Gpu)]
     ),
 )
 _TP_DASK = tuple(ArrayType("dask.array", "Array", Flags.Dask | t.flags, inner=t) for t in _TP_MEM)

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -60,6 +60,8 @@ class Flags(enum.Flag):
 
     Sparse = enum.auto()
     """Sparse array."""
+    Matrix = enum.auto()
+    """Matrix API (``A * B`` means ``A @ B``)."""
     Gpu = enum.auto()
     """GPU array."""
     Dask = enum.auto()


### PR DESCRIPTION
this goes back to only running benchmarks for csX_arrays, as matrices have the same performance