### PR TITLE
implement and test mean

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,10 +23,7 @@ version = meta["version"]
 release = version
 
 # default settings
-ource_suffix = {".rst": "restructuredtext"}
 master_doc = "index"
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-
 extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autodoc",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ version = meta["version"]
 release = version
 
 # default settings
-source_suffix = ".rst"
+ource_suffix = {".rst": "restructuredtext"}
 master_doc = "index"
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 

--- a/src/fast_array_utils/_validation.py
+++ b/src/fast_array_utils/_validation.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
-from numbers import Integral
+import numpy as np
 
 
 def validate_axis(axis: int | None) -> None:
     if axis is None:
         return
-    if not isinstance(axis, Integral):  # pragma: no cover
+    if not isinstance(axis, int | np.integer):  # pragma: no cover
         msg = "axis must be integer or None."
         raise TypeError(msg)
     if axis not in (0, 1):  # pragma: no cover

--- a/src/fast_array_utils/conv/_to_dense.py
+++ b/src/fast_array_utils/conv/_to_dense.py
@@ -90,7 +90,7 @@ def _to_dense(
 
 
 @_to_dense.register(types.CSBase)  # type: ignore[call-overload,misc]
-def _(x: types.CSBase, /, *, to_memory: bool = False) -> NDArray[Any]:
+def _to_dense_cs(x: types.CSBase, /, *, to_memory: bool = False) -> NDArray[Any]:
     from . import scipy
 
     del to_memory  # it already is
@@ -98,7 +98,9 @@ def _(x: types.CSBase, /, *, to_memory: bool = False) -> NDArray[Any]:
 
 
 @_to_dense.register(types.DaskArray)
-def _(x: types.DaskArray, /, *, to_memory: bool = False) -> NDArray[Any] | types.DaskArray:
+def _to_dense_dask(
+    x: types.DaskArray, /, *, to_memory: bool = False
+) -> NDArray[Any] | types.DaskArray:
     if TYPE_CHECKING:
         from dask.array.core import map_blocks
     else:
@@ -109,7 +111,7 @@ def _(x: types.DaskArray, /, *, to_memory: bool = False) -> NDArray[Any] | types
 
 
 @_to_dense.register(types.OutOfCoreDataset)
-def _(
+def _to_dense_ooc(
     x: types.OutOfCoreDataset[types.CSBase | NDArray[Any]], /, *, to_memory: bool = False
 ) -> NDArray[Any]:
     if not to_memory:
@@ -120,7 +122,7 @@ def _(
 
 
 @_to_dense.register(types.CupyArray | types.CupySparseMatrix)  # type: ignore[call-overload,misc]
-def _(
+def _to_dense_cupy(
     x: types.CupyArray | types.CupySparseMatrix, /, *, to_memory: bool = False
 ) -> NDArray[Any] | types.CupyArray:
     x = x.toarray() if isinstance(x, types.CupySparseMatrix) else x

--- a/src/fast_array_utils/stats/__init__.py
+++ b/src/fast_array_utils/stats/__init__.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 from ._is_constant import is_constant
+from ._mean import mean
 from ._sum import sum
 
 
-__all__ = ["is_constant", "sum"]
+__all__ = ["is_constant", "mean", "sum"]

--- a/src/fast_array_utils/stats/_mean.py
+++ b/src/fast_array_utils/stats/_mean.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MPL-2.0
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ._sum import sum as sum_
+
+
+if TYPE_CHECKING:
+    from typing import Any, Literal, TypeAlias
+
+    from numpy._typing._array_like import _ArrayLikeFloat_co
+    from numpy.typing import DTypeLike, NDArray
+
+    from .. import types
+
+    # all supported types except OutOfCoreDataset (TODO)
+    Array: TypeAlias = (
+        NDArray[Any]
+        | types.CSBase
+        | types.H5Dataset
+        | types.ZarrArray
+        | types.CupyArray
+        | types.CupySparseMatrix
+        | types.DaskArray
+    )
+
+
+def mean(
+    x: _ArrayLikeFloat_co | Array,
+    *,
+    axis: Literal[0, 1, None] = None,
+    dtype: DTypeLike | None = None,
+) -> NDArray[Any] | types.DaskArray:
+    if not hasattr(x, "shape"):
+        raise NotImplementedError  # TODO(flying-sheep): infer shape  # noqa: TD003
+    if TYPE_CHECKING:
+        assert isinstance(x, Array)
+    total = sum_(x, axis=axis, dtype=dtype)
+    n = np.prod(x.shape) if axis is None else x.shape[axis]
+    return total / n

--- a/src/fast_array_utils/stats/_mean.py
+++ b/src/fast_array_utils/stats/_mean.py
@@ -35,6 +35,17 @@ def mean(
     axis: Literal[0, 1, None] = None,
     dtype: DTypeLike | None = None,
 ) -> NDArray[Any] | types.DaskArray:
+    """Mean over both or one axis.
+
+    Returns
+    -------
+    If ``axis`` is :data:`None`, then the sum over all elements is returned as a scalar.
+    Otherwise, the sum over the given axis is returned as a 1D array.
+
+    See Also
+    --------
+    :func:`numpy.mean`
+    """
     if not hasattr(x, "shape"):
         raise NotImplementedError  # TODO(flying-sheep): infer shape  # noqa: TD003
     if TYPE_CHECKING:

--- a/src/fast_array_utils/stats/_mean.py
+++ b/src/fast_array_utils/stats/_mean.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 def mean(
     x: _ArrayLikeFloat_co | Array,
+    /,
     *,
     axis: Literal[0, 1, None] = None,
     dtype: DTypeLike | None = None,

--- a/src/fast_array_utils/stats/_mean.py
+++ b/src/fast_array_utils/stats/_mean.py
@@ -11,7 +11,7 @@ from ._sum import sum as sum_
 if TYPE_CHECKING:
     from typing import Any, Literal, TypeAlias
 
-    from numpy._typing._array_like import _ArrayLikeFloat_co
+    from numpy._typing._array_like import _ArrayLikeFloat_co as ArrayLike
     from numpy.typing import DTypeLike, NDArray
 
     from .. import types
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 def mean(
-    x: _ArrayLikeFloat_co | Array,
+    x: ArrayLike | Array,
     /,
     *,
     axis: Literal[0, 1, None] = None,

--- a/src/fast_array_utils/stats/_mean.py
+++ b/src/fast_array_utils/stats/_mean.py
@@ -9,7 +9,7 @@ from ._sum import sum as sum_
 
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, TypeAlias
+    from typing import Any, Literal
 
     from numpy._typing._array_like import _ArrayLikeFloat_co as ArrayLike
     from numpy.typing import DTypeLike, NDArray
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .. import types
 
     # all supported types except OutOfCoreDataset (TODO)
-    Array: TypeAlias = (
+    Array = (
         NDArray[Any]
         | types.CSBase
         | types.H5Dataset

--- a/src/fast_array_utils/stats/_sum.py
+++ b/src/fast_array_utils/stats/_sum.py
@@ -14,7 +14,7 @@ from .._validation import validate_axis
 if TYPE_CHECKING:
     from typing import Literal
 
-    from numpy._typing._array_like import _ArrayLikeFloat_co
+    from numpy._typing._array_like import _ArrayLikeFloat_co as ArrayLike
     from numpy.typing import DTypeLike
 
     # all supported types except CSBase, Dask and OutOfCoreDataset (TODO)
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 @overload
 def sum(
-    x: _ArrayLikeFloat_co | Array | types.CSBase,
+    x: ArrayLike | Array | types.CSBase,
     /,
     *,
     axis: None = None,
@@ -33,7 +33,7 @@ def sum(
 ) -> np.number[Any]: ...
 @overload
 def sum(
-    x: _ArrayLikeFloat_co | Array | types.CSBase,
+    x: ArrayLike | Array | types.CSBase,
     /,
     *,
     axis: Literal[0, 1],
@@ -46,7 +46,7 @@ def sum(
 
 
 def sum(
-    x: _ArrayLikeFloat_co | Array | types.CSBase | types.DaskArray,
+    x: ArrayLike | Array | types.CSBase | types.DaskArray,
     /,
     *,
     axis: Literal[0, 1, None] = None,
@@ -70,7 +70,7 @@ def sum(
 
 @singledispatch
 def _sum(
-    x: _ArrayLikeFloat_co | Array | types.CSBase | types.DaskArray,
+    x: ArrayLike | Array | types.CSBase | types.DaskArray,
     /,
     *,
     axis: Literal[0, 1, None] = None,
@@ -95,7 +95,7 @@ def _(
     if isinstance(x, types.CSMatrix):
         x = sp.csr_array(x) if x.format == "csr" else sp.csc_array(x)
     if TYPE_CHECKING:
-        assert isinstance(x, _ArrayLikeFloat_co)
+        assert isinstance(x, ArrayLike)
     return cast(NDArray[Any] | np.number[Any], np.sum(x, axis=axis, dtype=dtype))
 
 

--- a/src/fast_array_utils/stats/_sum.py
+++ b/src/fast_array_utils/stats/_sum.py
@@ -14,7 +14,8 @@ from .._validation import validate_axis
 if TYPE_CHECKING:
     from typing import Literal
 
-    from numpy.typing import ArrayLike, DTypeLike
+    from numpy._typing._array_like import _ArrayLikeFloat_co
+    from numpy.typing import DTypeLike
 
     # all supported types except CSBase, Dask and OutOfCoreDataset (TODO)
     Array = (
@@ -24,11 +25,19 @@ if TYPE_CHECKING:
 
 @overload
 def sum(
-    x: Array | types.CSBase, /, *, axis: None = None, dtype: DTypeLike | None = None
+    x: _ArrayLikeFloat_co | Array | types.CSBase,
+    /,
+    *,
+    axis: None = None,
+    dtype: DTypeLike | None = None,
 ) -> np.number[Any]: ...
 @overload
 def sum(
-    x: Array | types.CSBase, /, *, axis: Literal[0, 1], dtype: DTypeLike | None = None
+    x: _ArrayLikeFloat_co | Array | types.CSBase,
+    /,
+    *,
+    axis: Literal[0, 1],
+    dtype: DTypeLike | None = None,
 ) -> NDArray[Any]: ...
 @overload
 def sum(
@@ -37,7 +46,7 @@ def sum(
 
 
 def sum(
-    x: Array | types.CSBase | types.DaskArray,
+    x: _ArrayLikeFloat_co | Array | types.CSBase | types.DaskArray,
     /,
     *,
     axis: Literal[0, 1, None] = None,
@@ -61,7 +70,7 @@ def sum(
 
 @singledispatch
 def _sum(
-    x: Array | types.CSBase | types.DaskArray,
+    x: _ArrayLikeFloat_co | Array | types.CSBase | types.DaskArray,
     /,
     *,
     axis: Literal[0, 1, None] = None,
@@ -86,7 +95,7 @@ def _(
     if isinstance(x, types.CSMatrix):
         x = sp.csr_array(x) if x.format == "csr" else sp.csc_array(x)
     if TYPE_CHECKING:
-        assert isinstance(x, ArrayLike)
+        assert isinstance(x, _ArrayLikeFloat_co)
     return cast(NDArray[Any] | np.number[Any], np.sum(x, axis=axis, dtype=dtype))
 
 

--- a/src/fast_array_utils/stats/_sum.py
+++ b/src/fast_array_utils/stats/_sum.py
@@ -87,7 +87,7 @@ def _sum(
 
 
 @_sum.register(types.CSBase)  # type: ignore[call-overload,misc]
-def _(
+def _sum_cs(
     x: types.CSBase, /, *, axis: Literal[0, 1, None] = None, dtype: DTypeLike | None = None
 ) -> NDArray[Any] | np.number[Any]:
     import scipy.sparse as sp
@@ -100,7 +100,7 @@ def _(
 
 
 @_sum.register(types.DaskArray)
-def _(
+def _sum_dask(
     x: types.DaskArray, /, *, axis: Literal[0, 1, None] = None, dtype: DTypeLike | None = None
 ) -> types.DaskArray:
     import dask.array as da

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -14,12 +14,12 @@ from fast_array_utils import types
 
 
 if TYPE_CHECKING:
-    from typing import Any, Protocol, TypeAlias
+    from typing import Any, Protocol
 
     import h5py
     from numpy.typing import ArrayLike, DTypeLike, NDArray
 
-    Array: TypeAlias = (
+    Array = (
         NDArray[Any]
         | types.CSBase
         | types.CupyArray

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -12,7 +12,7 @@ from testing.fast_array_utils import Flags
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Any, Protocol, TypeAlias
+    from typing import Any, Protocol
 
     from numpy.typing import NDArray
     from pytest_codspeed import BenchmarkFixture
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     DTypeIn = type[np.float32 | np.float64 | np.int32 | np.bool]
     DTypeOut = type[np.float32 | np.float64 | np.int64]
 
-    Benchmarkable: TypeAlias = NDArray[Any] | types.CSBase
+    Benchmarkable = NDArray[Any] | types.CSBase
 
     class BenchFun(Protocol):  # noqa: D101
         def __call__(  # noqa: D102

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
     from pytest_codspeed import BenchmarkFixture
 
-    from fast_array_utils.stats._sum import Array
+    from fast_array_utils.stats._mean import Array
     from testing.fast_array_utils import ArrayType
 
     DTypeIn = type[np.float32 | np.float64 | np.int32 | np.bool]
@@ -54,7 +54,7 @@ def dtype_arg(request: pytest.FixtureRequest) -> DTypeOut | None:
 
 
 def test_sum(
-    array_type: ArrayType[Array | types.CSBase | types.DaskArray],
+    array_type: ArrayType[Array],
     dtype_in: DTypeIn,
     dtype_arg: DTypeOut | None,
     axis: Literal[0, 1, None],
@@ -86,6 +86,17 @@ def test_sum(
         assert sum_.dtype == dtype_in
 
     np.testing.assert_array_equal(sum_, np.sum(np_arr, axis=axis, dtype=dtype_arg))
+
+
+@pytest.mark.parametrize(("axis", "expected"), [(None, 3.5), (0, [2.5, 3.5, 4.5]), (1, [2.0, 5.0])])
+def test_mean(
+    array_type: ArrayType[Array], axis: Literal[0, 1, None], expected: list[float]
+) -> None:
+    arr = array_type(np.array([[1, 2, 3], [4, 5, 6]]))
+    result = stats.mean(arr, axis=axis)
+    if isinstance(result, types.DaskArray):
+        result = result.compute()  # type: ignore[no-untyped-call]
+    np.testing.assert_array_equal(result, expected)
 
 
 # TODO(flying-sheep): enable for GPU  # noqa: TD003
@@ -138,7 +149,7 @@ def test_dask_constant_blocks(
 
 @pytest.mark.benchmark
 @pytest.mark.array_type(skip=Flags.Matrix | Flags.Dask | Flags.Disk | Flags.Gpu)
-@pytest.mark.parametrize("func", [stats.sum, stats.is_constant])
+@pytest.mark.parametrize("func", [stats.sum, stats.mean, stats.is_constant])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])  # random only supports float
 def test_stats_benchmark(
     benchmark: BenchmarkFixture,


### PR DESCRIPTION
Fixes #43 

other than the scanpy impl, this uses our `sum` always to also work on e.g. sparse.

IDK what’s up with these CodSpeed regressions/improvements, these two benchmarks (only) seem to be super flaky