### PR TITLE
Allow array_type to convert from all types it supports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,9 @@ html_theme_options = dict(
 _np_nocls = {"float64": "attr"}
 _optional_types = {
     "CupyArray": "cupy.ndarray",
-    "CupySparseMatrix": "cupyx.scipy.sparse.spmatrix",
+    "CupySpMatrix": "cupyx.scipy.sparse.spmatrix",
+    "sparray": "scipy.sparse.sparray",
+    "spmatrix": "scipy.sparse.spmatrix",
     "DaskArray": "dask.array.Array",
     "H5Dataset": "h5py.Dataset",
     "ZarrArray": "zarr.Array",
@@ -100,7 +102,7 @@ def find_type_alias(name: str) -> tuple[str, str] | tuple[None, None]:
 
     if name in typing.__all__:
         return "data", f"fast_array_utils.typing.{name}"
-    if name.startswith("types.") and name[6:] in types.__all__:
+    if name.startswith("types.") and name[6:] in {*types.__all__, *_optional_types}:
         if path := _optional_types.get(name[6:]):
             return "class", path
         return "data", f"fast_array_utils.{name}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ intersphinx_mapping = dict(
 )
 nitpick_ignore = [
     ("py:class", "Arr"),
+    ("py:class", "Array"),
     ("py:class", "ToDType"),
     ("py:class", "testing.fast_array_utils._array_type.Arr"),
     ("py:class", "testing.fast_array_utils._array_type.Inner"),

--- a/src/fast_array_utils/conv/__init__.py
+++ b/src/fast_array_utils/conv/__init__.py
@@ -22,7 +22,10 @@ __all__ = ["to_dense"]
 
 @overload
 def to_dense(
-    x: CpuArray | DiskArray | types.CSDataset, /, *, to_memory: bool = False
+    x: CpuArray | DiskArray | types.sparray | types.spmatrix | types.CSDataset,
+    /,
+    *,
+    to_memory: bool = False,
 ) -> NDArray[Any]: ...
 
 
@@ -33,13 +36,22 @@ def to_dense(x: types.DaskArray, /, *, to_memory: Literal[True]) -> NDArray[Any]
 
 
 @overload
-def to_dense(x: GpuArray, /, *, to_memory: Literal[False] = False) -> types.CupyArray: ...
+def to_dense(
+    x: GpuArray | types.CupySpMatrix, /, *, to_memory: Literal[False] = False
+) -> types.CupyArray: ...
 @overload
-def to_dense(x: GpuArray, /, *, to_memory: Literal[True]) -> NDArray[Any]: ...
+def to_dense(x: GpuArray | types.CupySpMatrix, /, *, to_memory: Literal[True]) -> NDArray[Any]: ...
 
 
 def to_dense(
-    x: CpuArray | GpuArray | DiskArray | types.CSDataset | types.DaskArray,
+    x: CpuArray
+    | GpuArray
+    | DiskArray
+    | types.CSDataset
+    | types.DaskArray
+    | types.sparray
+    | types.spmatrix
+    | types.CupySpMatrix,
     /,
     *,
     to_memory: bool = False,

--- a/src/fast_array_utils/conv/scipy/_to_dense.py
+++ b/src/fast_array_utils/conv/scipy/_to_dense.py
@@ -11,15 +11,16 @@ if TYPE_CHECKING:
     from typing import Any, Literal
 
     from numpy.typing import NDArray
+    from scipy.sparse import coo_array, coo_matrix
 
-    from ...types import CSBase
+    from ... import types
 
 
 __all__ = ["to_dense"]
 
 
-def to_dense(x: CSBase, order: Literal["C", "F"] = "C") -> NDArray[Any]:
-    """Convert a compressed sparse matrix to a dense matrix.
+def to_dense(x: types.spmatrix | types.sparray, order: Literal["C", "F"] = "C") -> NDArray[Any]:
+    """Convert a sparse matrix to a dense matrix.
 
     Parameters
     ----------
@@ -33,6 +34,9 @@ def to_dense(x: CSBase, order: Literal["C", "F"] = "C") -> NDArray[Any]:
     Dense matrix form of ``x``
 
     """
+    if TYPE_CHECKING:
+        assert isinstance(x, types.CSBase | coo_matrix | coo_array)
+
     out = np.zeros(x.shape, dtype=x.dtype, order=order)
     if x.format == "csr":
         _to_dense_csr_numba(x.indptr, x.indices, x.data, out)

--- a/src/fast_array_utils/types.py
+++ b/src/fast_array_utils/types.py
@@ -17,6 +17,7 @@ __all__ = [
     "CupyCSCMatrix",
     "CupyCSMatrix",
     "CupyCSRMatrix",
+    "CupySpMatrix",
     "DaskArray",
     "H5Dataset",
     "H5Group",
@@ -54,12 +55,16 @@ if TYPE_CHECKING or find_spec("cupy"):  # cupy always comes with cupyx
     from cupy import ndarray as CupyArray
     from cupyx.scipy.sparse import csc_matrix as CupyCSCMatrix
     from cupyx.scipy.sparse import csr_matrix as CupyCSRMatrix
+    from cupyx.scipy.sparse import spmatrix as CupySpMatrix
 else:  # pragma: no cover
     CupyArray = type("ndarray", (), {})
     CupyArray.__module__ = "cupy"
     CupyCSCMatrix = type("csc_matrix", (), {})
     CupyCSRMatrix = type("csr_matrix", (), {})
-    CupyCSCMatrix.__module__ = CupyCSRMatrix.__module__ = "cupyx.scipy.sparse"
+    CupySpMatrix = type("spmatrix", (), {})
+    CupyCSCMatrix.__module__ = CupyCSRMatrix.__module__ = CupySpMatrix.__module__ = (
+        "cupyx.scipy.sparse"
+    )
 CupyCSMatrix = CupyCSRMatrix | CupyCSCMatrix
 
 

--- a/src/fast_array_utils/types.py
+++ b/src/fast_array_utils/types.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, TypeVar
 
+from scipy.sparse import sparray, spmatrix
+
 
 __all__ = [
     "CSArray",
@@ -33,18 +35,20 @@ if TYPE_CHECKING:
     from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
 else:
     try:  # cs?_array isn’t available in older scipy versions
-        from scipy.sparse import csc_array, csr_array
+        from scipy.sparse import csc_array, csr_array, sparray
     except ImportError:  # pragma: no cover
         csc_array = type("csc_array", (), {})
         csr_array = type("csr_array", (), {})
-        csc_array.__module__ = csr_array.__module__ = "scipy.sparse"
+        sparray = type("sparray", (), {})
+        csc_array.__module__ = csr_array.__module__ = sparray.__module__ = "scipy.sparse"
 
     try:  # cs?_matrix is available when scipy is installed
-        from scipy.sparse import csc_matrix, csr_matrix
+        from scipy.sparse import csc_matrix, csr_matrix, spmatrix
     except ImportError:  # pragma: no cover
         csc_matrix = type("csc_matrix", (), {})
         csr_matrix = type("csr_matrix", (), {})
-        csc_matrix.__module__ = csr_matrix.__module__ = "scipy.sparse"
+        spmatrix = type("spmatrix", (), {})
+        csc_matrix.__module__ = csr_matrix.__module__ = spmatrix.__module__ = "scipy.sparse"
 CSMatrix = csc_matrix | csr_matrix
 CSArray = csc_array | csr_array
 CSBase = CSMatrix | CSArray

--- a/src/fast_array_utils/types.py
+++ b/src/fast_array_utils/types.py
@@ -6,12 +6,9 @@ from __future__ import annotations
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, TypeVar
 
-from scipy.sparse import sparray, spmatrix
-
 
 __all__ = [
     "CSArray",
-    "CSBase",
     "CSBase",
     "CSDataset",
     "CSMatrix",
@@ -32,7 +29,7 @@ T_co = TypeVar("T_co", covariant=True)
 
 # scipy sparse
 if TYPE_CHECKING:
-    from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
+    from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix, sparray, spmatrix
 else:
     try:  # cs?_array isn’t available in older scipy versions
         from scipy.sparse import csc_array, csr_array, sparray

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -279,14 +279,14 @@ class ArrayType(Generic[Arr, Inner]):
         arr = self._to_numpy_array(x, dtype=dtype)
         return ctx.hdf5_file.create_dataset("data", arr.shape, arr.dtype, data=arr)
 
-    @staticmethod
+    @classmethod
     def _to_zarr_array(
-        x: ArrayLike | Array, /, *, dtype: DTypeLike | None = None
+        cls, x: ArrayLike | Array, /, *, dtype: DTypeLike | None = None
     ) -> types.ZarrArray:
         """Convert to a zarr array."""
         import zarr
 
-        arr = ArrayType._to_numpy_array(x, dtype=dtype)
+        arr = cls._to_numpy_array(x, dtype=dtype)
         if Version(version("zarr")) >= Version("3"):
             za = zarr.create_array({}, shape=arr.shape, dtype=arr.dtype)
         else:

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -374,7 +374,7 @@ class ArrayType(Generic[Arr, Inner]):
         if not isinstance(x, types.spmatrix | types.sparray | types.CupyArray | types.CupySpMatrix):
             x = self._to_cupy_array(x, dtype=dtype)
 
-        return self.cls(x)  # type: ignore[call-overload,call-arg,arg-type, return-value]
+        return self.cls(x)  # type: ignore[call-arg,arg-type, return-value]
 
 
 def random_mat(

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -261,7 +261,7 @@ class ArrayType(Generic[Arr, Inner]):
             if isinstance(x._meta, self.inner.cls):  # noqa: SLF001
                 return x
             return x.map_blocks(
-                self.inner, dtype=dtype, meta=self.inner([1], dtype=dtype or x.dtype)
+                self.inner, dtype=dtype, meta=self.inner([[1]], dtype=dtype or x.dtype)
             )
 
         arr = self.inner(x, dtype=dtype)

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -12,6 +12,9 @@ from typing import TYPE_CHECKING, Generic, TypeVar, cast
 import numpy as np
 from packaging.version import Version
 
+from fast_array_utils import types
+from fast_array_utils.conv import to_dense
+
 
 if TYPE_CHECKING:
     from typing import Any, Literal, Protocol, TypeAlias
@@ -19,7 +22,6 @@ if TYPE_CHECKING:
     import h5py
     from numpy.typing import ArrayLike, DTypeLike, NDArray
 
-    from fast_array_utils import types
     from fast_array_utils.types import CSBase
     from fast_array_utils.typing import CpuArray, DiskArray, GpuArray
 
@@ -209,8 +211,6 @@ class ArrayType(Generic[Arr, Inner]):
 
     def __call__(self, x: ArrayLike | Array, /, *, dtype: DTypeLike | None = None) -> Arr:
         """Convert to this array type."""
-        from fast_array_utils import types
-
         fn: ToArray[Arr]
         if self.cls is np.ndarray:
             fn = cast("ToArray[Arr]", self._to_numpy_array)
@@ -241,8 +241,6 @@ class ArrayType(Generic[Arr, Inner]):
         x: ArrayLike | Array, /, *, dtype: DTypeLike | None = None
     ) -> NDArray[np.number[Any]]:
         """Convert to a numpy array."""
-        from fast_array_utils.conv import to_dense
-
         x = to_dense(x, to_memory=True)
         return x if dtype is None else x.astype(dtype)
 
@@ -251,8 +249,6 @@ class ArrayType(Generic[Arr, Inner]):
     ) -> types.DaskArray:
         """Convert to a dask array."""
         import dask.array as da
-
-        from fast_array_utils import types
 
         assert self.inner is not None
         if TYPE_CHECKING:
@@ -301,8 +297,6 @@ class ArrayType(Generic[Arr, Inner]):
         import anndata.io  # type: ignore[import-untyped]
         from scipy.sparse import csc_array, csr_array
 
-        from fast_array_utils import types
-
         assert self.inner is not None
 
         grp: types.H5Group | types.ZarrGroup
@@ -332,9 +326,6 @@ class ArrayType(Generic[Arr, Inner]):
         cls: type[CSBase] | None = None,
     ) -> types.CSBase:
         """Convert to a scipy sparse matrix/array."""
-        from fast_array_utils import types
-        from fast_array_utils.conv import to_dense
-
         if isinstance(x, types.DaskArray):
             x = x.compute()
         if isinstance(x, types.CupySpMatrix):
@@ -349,9 +340,6 @@ class ArrayType(Generic[Arr, Inner]):
         self, x: ArrayLike | Array, /, *, dtype: DTypeLike | None = None
     ) -> types.CupyArray:
         import cupy as cu
-
-        from fast_array_utils import types
-        from fast_array_utils.conv import to_dense
 
         if isinstance(x, types.DaskArray):
             x = x.compute()  # this could now be a cupy array already
@@ -369,8 +357,6 @@ class ArrayType(Generic[Arr, Inner]):
         *,
         dtype: DTypeLike | None = None,
     ) -> types.CupyCSMatrix:
-        from fast_array_utils import types
-
         if not isinstance(x, types.spmatrix | types.sparray | types.CupyArray | types.CupySpMatrix):
             x = self._to_cupy_array(x, dtype=dtype)
 

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -267,7 +267,10 @@ class ArrayType(Generic[Arr, Inner]):
         if (ctx := self.conversion_context) is None:
             msg = "`conversion_context` must be set for h5py"
             raise RuntimeError(msg)
-        arr = np.asarray(x, dtype=dtype)
+
+        from fast_array_utils.conv import to_dense
+
+        arr = to_dense(x, to_memory=True).astype(dtype)
         return ctx.hdf5_file.create_dataset("data", arr.shape, arr.dtype, data=arr)
 
     @staticmethod
@@ -277,7 +280,9 @@ class ArrayType(Generic[Arr, Inner]):
         """Convert to a zarr array."""
         import zarr
 
-        arr = np.asarray(x, dtype=dtype)
+        from fast_array_utils.conv import to_dense
+
+        arr = to_dense(x, to_memory=True).astype(dtype)
         if Version(version("zarr")) >= Version("3"):
             za = zarr.create_array({}, shape=arr.shape, dtype=arr.dtype)
         else:

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -270,7 +270,9 @@ class ArrayType(Generic[Arr, Inner]):
 
         from fast_array_utils.conv import to_dense
 
-        arr = to_dense(x, to_memory=True).astype(dtype)
+        arr = to_dense(x, to_memory=True)
+        if dtype is not None:
+            arr = arr.astype(dtype)
         return ctx.hdf5_file.create_dataset("data", arr.shape, arr.dtype, data=arr)
 
     @staticmethod
@@ -282,7 +284,9 @@ class ArrayType(Generic[Arr, Inner]):
 
         from fast_array_utils.conv import to_dense
 
-        arr = to_dense(x, to_memory=True).astype(dtype)
+        arr = to_dense(x, to_memory=True)
+        if dtype is not None:
+            arr = arr.astype(dtype)
         if Version(version("zarr")) >= Version("3"):
             za = zarr.create_array({}, shape=arr.shape, dtype=arr.dtype)
         else:

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -341,7 +341,7 @@ class ArrayType(Generic[Arr, Inner]):
         elif not isinstance(x, spmatrix | np.ndarray):
             x = to_dense(x, to_memory=True)
 
-        cls = cast("types.CSBase", cls or self.cls)
+        cls = cast("type[types.CSBase]", cls or self.cls)
         return cls(x, dtype=dtype)  # type: ignore[arg-type]
 
     def _to_cupy_array(
@@ -375,7 +375,7 @@ class ArrayType(Generic[Arr, Inner]):
         if not isinstance(x, spmatrix | types.CupyArray | types.CupySpMatrix):
             x = self._to_cupy_array(x, dtype=dtype)
 
-        return self.cls(x)  # type: ignore[call-overload,call-arg,arg-type]
+        return self.cls(x)  # type: ignore[call-overload,call-arg,arg-type, return-value]
 
 
 def random_mat(

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -349,7 +349,17 @@ class ArrayType(Generic[Arr, Inner]):
     ) -> types.CupyArray:
         import cupy as cu
 
-        return cu.asarray(x, dtype=np.dtype(dtype))
+        from fast_array_utils import types
+        from fast_array_utils.conv import to_dense
+
+        if isinstance(x, types.DaskArray):
+            x = x.compute()  # this could now be a cupy array already
+        if isinstance(x, types.CupySpMatrix):
+            x = x.toarray()
+        if isinstance(x, types.CSDataset | types.CSBase):
+            x = to_dense(x, to_memory=True)
+
+        return cu.asarray(x, dtype=None if dtype is None else np.dtype(dtype))
 
     def _to_cupy_sparse(
         self,

--- a/src/testing/fast_array_utils/_array_type.py
+++ b/src/testing/fast_array_utils/_array_type.py
@@ -243,7 +243,7 @@ class ArrayType(Generic[Arr, Inner]):
         from fast_array_utils.conv import to_dense
 
         x = to_dense(x, to_memory=True)
-        return x if dtype == None else x.astype(dtype)
+        return x if dtype is None else x.astype(dtype)
 
     def _to_dask_array(
         self, x: ArrayLike | Array, /, *, dtype: DTypeLike | None = None

--- a/src/testing/fast_array_utils/pytest.py
+++ b/src/testing/fast_array_utils/pytest.py
@@ -12,6 +12,9 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 
+from fast_array_utils import types
+from testing.fast_array_utils import ConversionContext
+
 from . import SUPPORTED_TYPES, ArrayType, Flags
 
 
@@ -114,14 +117,10 @@ def array_type(request: pytest.FixtureRequest, tmp_path: Path) -> Generator[Arra
             def test_something(array_type: ArrayType) -> None:
                 ...
     """
-    from fast_array_utils.types import H5Dataset
-
     at = cast("ArrayType", request.param)
     f: h5py.File | None = None
-    if at.cls is H5Dataset or (at.inner and at.inner.cls is H5Dataset):
+    if at.cls is types.H5Dataset or (at.inner and at.inner.cls is types.H5Dataset):
         import h5py
-
-        from testing.fast_array_utils._array_type import ConversionContext
 
         f = h5py.File(tmp_path / f"{request.fixturename}.h5", "w")
         ctx = ConversionContext(hdf5_file=f)

--- a/src/testing/fast_array_utils/pytest.py
+++ b/src/testing/fast_array_utils/pytest.py
@@ -10,10 +10,7 @@ import dataclasses
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, cast
 
-import h5py
 import pytest
-
-from testing.fast_array_utils._array_type import ConversionContext
 
 from . import SUPPORTED_TYPES, ArrayType, Flags
 
@@ -21,6 +18,8 @@ from . import SUPPORTED_TYPES, ArrayType, Flags
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
     from pathlib import Path
+
+    import h5py
 
 
 __all__ = ["SUPPORTED_TYPE_PARAMS", "array_type"]
@@ -120,6 +119,10 @@ def array_type(request: pytest.FixtureRequest, tmp_path: Path) -> Generator[Arra
     at = cast("ArrayType", request.param)
     f: h5py.File | None = None
     if at.cls is H5Dataset or (at.inner and at.inner.cls is H5Dataset):
+        import h5py
+
+        from testing.fast_array_utils._array_type import ConversionContext
+
         f = h5py.File(tmp_path / f"{request.fixturename}.h5", "w")
         ctx = ConversionContext(hdf5_file=f)
         at = dataclasses.replace(at, conversion_context=ctx)

--- a/src/testing/fast_array_utils/pytest.py
+++ b/src/testing/fast_array_utils/pytest.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-__all__ = ["SUPPORTED_TYPE_PARAMS", "array_type", "conversion_context"]
+__all__ = ["SUPPORTED_TYPE_PARAMS", "array_type"]
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 
+from testing.fast_array_utils import ArrayType
+from testing.fast_array_utils.pytest import _skip_if_unimportable
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -25,3 +28,18 @@ def dask_viz(request: pytest.FixtureRequest, cache: pytest.Cache) -> Callable[[o
         obj.visualize(str(path), engine="ipycytoscape")
 
     return viz
+
+
+@pytest.fixture(
+    scope="session",
+    params=[
+        ("scipy.sparse", "coo_matrix"),
+        ("scipy.sparse", "coo_array"),
+        ("cupyx.scipy.sparse", "coo_matrix"),
+    ],
+    ids=["scipy.sparse.coo_matrix", "scipy.sparse.coo_array", "cupyx.scipy.sparse.coo_matrix"],
+)
+def coo_matrix_type(request: pytest.FixtureRequest) -> ArrayType:
+    at = ArrayType(*request.param)
+    request.applymarker(_skip_if_unimportable(at))
+    return at

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,16 +30,16 @@ def dask_viz(request: pytest.FixtureRequest, cache: pytest.Cache) -> Callable[[o
     return viz
 
 
-@pytest.fixture(
-    scope="session",
-    params=[
+COO_PARAMS = [
+    pytest.param(at := ArrayType(mod, name), id=f"{mod}.{name}", marks=_skip_if_unimportable(at))
+    for mod, name in [
         ("scipy.sparse", "coo_matrix"),
         ("scipy.sparse", "coo_array"),
         ("cupyx.scipy.sparse", "coo_matrix"),
-    ],
-    ids=["scipy.sparse.coo_matrix", "scipy.sparse.coo_array", "cupyx.scipy.sparse.coo_matrix"],
-)
+    ]
+]
+
+
+@pytest.fixture(scope="session", params=COO_PARAMS)
 def coo_matrix_type(request: pytest.FixtureRequest) -> ArrayType:
-    at = ArrayType(*request.param)
-    request.applymarker(_skip_if_unimportable(at))
-    return at
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,4 +42,4 @@ COO_PARAMS = [
 
 @pytest.fixture(scope="session", params=COO_PARAMS)
 def coo_matrix_type(request: pytest.FixtureRequest) -> ArrayType:
-    return request.param
+    return cast("ArrayType", request.param)

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -8,12 +8,16 @@ import pytest
 
 from fast_array_utils import types
 from testing.fast_array_utils import Flags
+from testing.fast_array_utils.pytest import array_type
 
 
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
 
     from testing.fast_array_utils import ArrayType
+
+
+other_array_type = array_type
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
@@ -26,6 +30,12 @@ def test_conv(array_type: ArrayType, dtype: DTypeLike) -> None:
         arr = arr.get()
     assert arr.shape == (3, 4)
     assert arr.dtype == dtype
+
+
+def test_conv_other(array_type: ArrayType, other_array_type: ArrayType) -> None:
+    arr = array_type(np.arange(12).reshape(3, 4), dtype=np.float32)
+    other_arr = other_array_type(arr)
+    assert isinstance(other_arr, other_array_type.cls)
 
 
 def test_array_types(array_type: ArrayType) -> None:

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from fast_array_utils import types
-from testing.fast_array_utils import ArrayType, Flags
+from testing.fast_array_utils import Flags
 from testing.fast_array_utils.pytest import array_type
 
 
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from cupyx.scipy.sparse import coo_matrix as CupyCooMatrix
     from numpy.typing import DTypeLike, NDArray
     from scipy.sparse import coo_array, coo_matrix
+
+    from testing.fast_array_utils import ArrayType
 
 
 other_array_type = array_type

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -33,9 +33,15 @@ def test_conv(array_type: ArrayType, dtype: DTypeLike) -> None:
 
 
 def test_conv_other(array_type: ArrayType, other_array_type: ArrayType) -> None:
-    arr = array_type(np.arange(12).reshape(3, 4), dtype=np.float32)
-    other_arr = other_array_type(arr)
-    assert isinstance(other_arr, other_array_type.cls)
+    src_arr = array_type(np.arange(12).reshape(3, 4), dtype=np.float32)
+    arr = other_array_type(src_arr)
+    assert isinstance(arr, other_array_type.cls)
+    if isinstance(arr, types.DaskArray):
+        arr = arr.compute()
+    elif isinstance(arr, types.CupyArray):
+        arr = arr.get()
+    assert arr.shape == (3, 4)
+    assert arr.dtype == np.float32
 
 
 def test_array_types(array_type: ArrayType) -> None:

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -14,7 +14,9 @@ from testing.fast_array_utils.pytest import array_type
 if TYPE_CHECKING:
     from typing import Any
 
+    from cupyx.scipy.sparse import coo_matrix as CupyCooMatrix
     from numpy.typing import DTypeLike, NDArray
+    from scipy.sparse import coo_array, coo_matrix
 
 
 other_array_type = array_type
@@ -44,22 +46,15 @@ def test_conv_other(array_type: ArrayType, other_array_type: ArrayType) -> None:
     assert arr.dtype == np.float32
 
 
-@pytest.mark.parametrize(
-    ("mod", "name"),
-    [
-        ("scipy.sparse", "coo_matrix"),
-        ("scipy.sparse", "coo_array"),
-        ("cupyx.scipy.sparse", "coo_matrix"),
-    ],
-)
 @pytest.mark.array_type(skip=Flags.Dask | Flags.Disk | Flags.Gpu)
 def test_conv_extra(
-    array_type: ArrayType[NDArray[np.number[Any]] | types.CSBase], mod: str, name: str
+    array_type: ArrayType[NDArray[np.number[Any]] | types.CSBase],
+    coo_matrix_type: ArrayType[coo_matrix | coo_array | CupyCooMatrix],
 ) -> None:
     src_arr = array_type(np.arange(12).reshape(3, 4), dtype=np.float32)
-    arr = ArrayType(mod, name)(src_arr)
-    assert type(arr).__module__.startswith(mod)
-    assert type(arr).__name__ == name
+    arr = coo_matrix_type(src_arr)
+    assert type(arr).__module__.startswith(coo_matrix_type.mod)
+    assert type(arr).__name__ == coo_matrix_type.name
     assert arr.shape == (3, 4)
     assert arr.dtype == np.float32
 

--- a/tests/test_to_dense.py
+++ b/tests/test_to_dense.py
@@ -32,12 +32,20 @@ def test_to_dense(array_type: ArrayType[Array], *, to_memory: bool) -> None:
     assert arr.shape == (2, 3)
 
 
+@pytest.mark.parametrize("to_memory", [True, False], ids=["to_memory", "not_to_memory"])
+def test_to_dense_extra(coo_matrix_type: ArrayType[Array], *, to_memory: bool) -> None:
+    src_mtx = coo_matrix_type([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+    arr = to_dense(src_mtx, to_memory=to_memory)
+    assert_expected_cls(src_mtx, arr, to_memory=to_memory)
+    assert arr.shape == (2, 3)
+
+
 def assert_expected_cls(orig: Array, converted: Array, *, to_memory: bool) -> None:
     match (to_memory, orig):
         case False, types.DaskArray():
             assert isinstance(converted, types.DaskArray)
             assert_expected_cls(orig._meta, converted._meta, to_memory=to_memory)  # noqa: SLF001
-        case False, types.CupyArray() | types.CupyCSCMatrix() | types.CupyCSRMatrix():
+        case False, types.CupyArray() | types.CupySpMatrix():
             assert isinstance(converted, types.CupyArray)
         case _:
             assert isinstance(converted, np.ndarray)

--- a/typings/cupy/_creation/from_data.pyi
+++ b/typings/cupy/_creation/from_data.pyi
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: MPL-2.0
 from typing import Literal
 
+import h5py
+import zarr
 from numpy.typing import ArrayLike, DTypeLike
 
 from .._core import ndarray
 
 def asarray(
-    a: ArrayLike,
+    a: ArrayLike | h5py.Dataset | zarr.Array,
     dtype: DTypeLike | None = None,
     order: Literal["C", "F", "A", "K", None] = None,
     *,

--- a/typings/cupyx/scipy/sparse/__init__.pyi
+++ b/typings/cupyx/scipy/sparse/__init__.pyi
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 from ._base import spmatrix as spmatrix
+from ._coo import coo_matrix as coo_matrix
 from ._csc import csc_matrix as csc_matrix
 from ._csr import csr_matrix as csr_matrix

--- a/typings/cupyx/scipy/sparse/_base.pyi
+++ b/typings/cupyx/scipy/sparse/_base.pyi
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
 from typing import Any, Literal, Self
 
-import cupy
+import cupy.cuda
 import numpy as np
+import scipy.sparse as sps
 from numpy.typing import NDArray
 
 class spmatrix:
@@ -11,3 +12,4 @@ class spmatrix:
     def toarray(self, order: Literal["C", "F", None] = None, out: None = None) -> cupy.ndarray: ...
     def __power__(self, other: int) -> Self: ...
     def __array__(self) -> NDArray[Any]: ...
+    def get(self, stream: cupy.cuda.Stream | None = None) -> sps.spmatrix: ...

--- a/typings/cupyx/scipy/sparse/_coo.pyi
+++ b/typings/cupyx/scipy/sparse/_coo.pyi
@@ -1,0 +1,10 @@
+from typing import Literal
+
+import cupy.cuda
+import scipy.sparse as sps
+
+from ._base import spmatrix
+
+class coo_matrix(spmatrix):
+    format: Literal["coo"] = "coo"
+    def get(self, stream: cupy.cuda.Stream | None = None) -> sps.spmatrix: ...

--- a/typings/cupyx/scipy/sparse/_coo.pyi
+++ b/typings/cupyx/scipy/sparse/_coo.pyi
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MPL-2.0
 from typing import Literal
 
 import cupy.cuda


### PR DESCRIPTION
Fixes #61

TODO:

- [ ] Maybe check converting `coo_matrix` (cupy and scipy)
- [x] fix docs