### PR TITLE
Derive test configs from hatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           filter: blob:none
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+      - run: uvx hatch env show --json
       - name: Get test environments
         id: get-envs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,11 @@ jobs:
           filter: blob:none
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-      - run: uvx hatch env show --json
       - name: Get test environments
         id: get-envs
         run: |
           ENVS_JSON=$(
-            uvx hatch env show --json |
+            FORCE_COLOR= uvx hatch env show --json |
             jq -c 'to_entries | map(select(.key | startswith("hatch-test")) | { name: .key, python: .value.python })'
           )
           echo "envs=${ENVS_JSON}" | tee $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       envs: ${{ steps.get-envs.outputs.envs }}
-      pythons: ${{ steps.get-envs.outputs.pythons }}
+      pythons: ${{ steps.get-pythons.outputs.pythons }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,9 +31,13 @@ jobs:
             FORCE_COLOR= uvx hatch env show --json |
             jq -c 'to_entries | map(select(.key | startswith("hatch-test")) | { name: .key, python: .value.python })'
           )
-          PYTHONS_JSON=$(echo "$ENVS_JSON" | jq -c 'map(.python) | unique')
-
           echo "envs=$ENVS_JSON" | tee $GITHUB_OUTPUT
+      - name: Get python versions
+        id: get-pythons
+        env:
+          ENVS_JSON: ${{ steps.get-envs.outputs.envs }}
+        run: |
+          PYTHONS_JSON=$(echo "$ENVS_JSON" | jq -c 'map(.python) | unique')
           echo "pythons=$PYTHONS_JSON" | tee $GITHUB_OUTPUT
   test:
     name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,34 +12,48 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
-  test:
-    name: Tests
+  get-environments:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - python-version: "3.13"
-            test-extra: test-min
-          - python-version: "3.11"
-          - python-version: "3.13"
+    outputs:
+      envs: ${{ steps.get-envs.outputs.envs }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           filter: blob:none
-      - uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Get test environments
+        id: get-envs
+        run: |
+          ENVS_JSON=$(
+            uvx hatch env show --json |
+            jq -c 'to_entries | map(select(.key | startswith("hatch-test")) | { name: .key, python: .value.python })'
+          )
+          echo "envs=${ENVS_JSON}" | tee $GITHUB_OUTPUT
+  test:
+    name: Tests
+    needs: get-environments
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.get-environments.outputs.envs) }}
+    steps:
+      - uses: actions/checkout@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          fetch-depth: 0
+          filter: blob:none
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: pyproject.toml
-      - run: uv pip install --system -e .[${{ matrix.test-extra || 'test' }}]
-      - run: |
-          coverage run -m pytest -m "not benchmark"
-          coverage report
+          python-version: ${{ matrix.env.python }}
+      - name: create environment
+        run: uvx hatch env create ${{ matrix.env.name }}
+      - name: run tests with coverage
+        run: |
+          hatch run ${{ matrix.env.name }}:run-cov
           # https://github.com/codecov/codecov-cli/issues/648
-          coverage xml
+          hatch run ${{ matrix.env.name }}:coverage xml
           rm test-data/.coverage
       - uses: codecov/codecov-action@v5
         with:
@@ -99,3 +113,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: pre-commit/action@v3.0.1
+  pass:
+    name: All Checks
+    if: always()
+    needs:
+      - get-environments
+      - test
+      - bench
+      - import
+      - check
+    runs-on: ubuntu-latest
+    steps:
+        - uses: re-actors/alls-green@release/v1
+          with:
+            jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       envs: ${{ steps.get-envs.outputs.envs }}
+      pythons: ${{ steps.get-envs.outputs.pythons }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,7 +31,8 @@ jobs:
             FORCE_COLOR= uvx hatch env show --json |
             jq -c 'to_entries | map(select(.key | startswith("hatch-test")) | { name: .key, python: .value.python })'
           )
-          echo "envs=${ENVS_JSON}" | tee $GITHUB_OUTPUT
+          echo "envs=$ENVS_JSON" | tee $GITHUB_OUTPUT
+          echo "pythons=$(echo $ENVS_JSON | jq -c 'map(.python) | unique')" | tee $GITHUB_OUTPUT
   test:
     name: Tests
     needs: get-environments
@@ -58,7 +60,7 @@ jobs:
           rm test-data/.coverage
       - uses: codecov/codecov-action@v5
         with:
-          name: Min Tests
+          name: ${{ matrix.env.name }}
           fail_ci_if_error: true
           files: test-data/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -99,10 +101,11 @@ jobs:
       - run: python -c 'import testing.fast_array_utils as tfau; print(tfau.ArrayType("numpy", "ndarray"))'
   check:
     name: Static Checks
+    needs: get-environments
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.13"]
+        python-version: ${{ fromJSON(needs.get-environments.outputs.pythons) }}
     env:
       SKIP: no-commit-to-branch  # this CI runs on the main branch
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
             FORCE_COLOR= uvx hatch env show --json |
             jq -c 'to_entries | map(select(.key | startswith("hatch-test")) | { name: .key, python: .value.python })'
           )
+          PYTHONS_JSON=$(echo "$ENVS_JSON" | jq -c 'map(.python) | unique')
+
           echo "envs=$ENVS_JSON" | tee $GITHUB_OUTPUT
-          echo "pythons=$(echo $ENVS_JSON | jq -c 'map(.python) | unique')" | tee $GITHUB_OUTPUT
+          echo "pythons=$PYTHONS_JSON" | tee $GITHUB_OUTPUT
   test:
     name: Tests
     needs: get-environments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
         run: uvx hatch env create ${{ matrix.env.name }}
       - name: run tests with coverage
         run: |
-          hatch run ${{ matrix.env.name }}:run-cov
+          uvx hatch run ${{ matrix.env.name }}:run-cov
           # https://github.com/codecov/codecov-cli/issues/648
-          hatch run ${{ matrix.env.name }}:coverage xml
+          uvx hatch run ${{ matrix.env.name }}:coverage xml
           rm test-data/.coverage
       - uses: codecov/codecov-action@v5
         with:
@@ -125,6 +125,6 @@ jobs:
       - check
     runs-on: ubuntu-latest
     steps:
-        - uses: re-actors/alls-green@release/v1
-          with:
-            jobs: ${{ toJSON(needs) }}
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
     needs: get-environments
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJSON(needs.get-environments.outputs.envs) }}
+      matrix:
+        env: ${{ fromJSON(needs.get-environments.outputs.envs) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ extra-dependencies = [ "ipykernel", "ipycytoscape" ]
 env-vars.CODSPEED_PROFILE_FOLDER = "test-data/codspeed"
 overrides.matrix.extras.features = [
   { if = [ "full" ], value = "full" },
-  { if = [ "default", "full" ], value = "test" },
+  { if = [ "full" ], value = "test" },
 ]
 overrides.matrix.extras.dependencies = [
   { if = [ "full" ], value = "scipy-stubs" },
@@ -89,8 +89,8 @@ overrides.matrix.extras.dependencies = [
 ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = [ "3.13", "3.12", "3.11" ]
-extras = [ "full", "default", "min" ]
+python = [ "3.13", "3.11" ]
+extras = [ "full", "min" ]
 
 [tool.ruff]
 line-length = 160


### PR DESCRIPTION
- Remove “standard” hatch test config, leaving only `product(["min", "full"], ["3.11", "3.13])
- Test all hatch test configs
- switch to [alls-green](https://github.com/re-actors/alls-green) so hatch test config changes don’t require rule changes