### PR TITLE
Add min max

### DIFF
--- a/src/fast_array_utils/stats/__init__.py
+++ b/src/fast_array_utils/stats/__init__.py
@@ -266,3 +266,27 @@ def sum(
 
     validate_axis(x.ndim, axis)
     return sum_(x, axis=axis, dtype=dtype, keep_cupy_as_array=keep_cupy_as_array)
+
+
+def min(
+    x: CpuArray | GpuArray | DiskArray | types.DaskArray,
+    /,
+    *,
+    axis: Literal[0, 1, None] = None,
+    keep_cupy_as_array: bool = False,
+) -> NDArray[Any] | types.CupyArray | np.number[Any] | types.DaskArray:
+    from ._min_max import min_max
+
+    return min_max("min", x, axis=axis, keep_cupy_as_array=keep_cupy_as_array)
+
+
+def max(
+    x: CpuArray | GpuArray | DiskArray | types.DaskArray,
+    /,
+    *,
+    axis: Literal[0, 1, None] = None,
+    keep_cupy_as_array: bool = False,
+) -> NDArray[Any] | types.CupyArray | np.number[Any] | types.DaskArray:
+    from ._min_max import min_max
+
+    return min_max("max", x, axis=axis, keep_cupy_as_array=keep_cupy_as_array)

--- a/src/fast_array_utils/stats/_min_max.py
+++ b/src/fast_array_utils/stats/_min_max.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: MPL-2.0
+from __future__ import annotations
+
+from functools import partial, singledispatch
+from typing import TYPE_CHECKING, cast, overload
+
+import numpy as np
+from numpy.exceptions import AxisError
+
+from .. import types
+from . import validate_axis
+
+
+if TYPE_CHECKING:
+    from typing import Any, Literal, TypeAlias
+
+    from numpy.typing import NDArray
+
+    from ..typing import CpuArray, DiskArray, GpuArray
+
+    ComplexAxis: TypeAlias = tuple[Literal[0], Literal[1]] | tuple[Literal[0, 1]] | Literal[0, 1, None]
+
+    MinMaxOps = Literal["max", "min"]
+
+
+@overload
+def min_max(ops: MinMaxOps, x: CpuArray | DiskArray, /, *, axis: None = None, keep_cupy_as_array: bool = False) -> np.number[Any]: ...
+@overload
+def min_max(ops: MinMaxOps, x: CpuArray | DiskArray, /, *, axis: Literal[0, 1], keep_cupy_as_array: bool = False) -> NDArray[Any]: ...
+
+
+@overload
+def min_max(ops: MinMaxOps, x: GpuArray, /, *, axis: None = None, keep_cupy_as_array: Literal[False] = False) -> np.number[Any]: ...
+@overload
+def min_max(ops: MinMaxOps, x: GpuArray, /, *, axis: None, keep_cupy_as_array: Literal[True]) -> types.CupyArray: ...
+@overload
+def min_max(ops: MinMaxOps, x: GpuArray, /, *, axis: Literal[0, 1], keep_cupy_as_array: bool = False) -> types.CupyArray: ...
+
+
+@overload
+def min_max(ops: MinMaxOps, x: types.DaskArray, /, *, axis: Literal[0, 1, None] = None, keep_cupy_as_array: bool = False) -> types.DaskArray: ...
+
+
+def min_max(
+    ops: MinMaxOps,
+    x: CpuArray | GpuArray | DiskArray | types.DaskArray,
+    /,
+    *,
+    axis: Literal[0, 1, None] = None,
+    keep_cupy_as_array: bool = False,
+) -> NDArray[Any] | types.CupyArray | np.number[Any] | types.DaskArray:
+    from ._min_max import min_max_
+
+    validate_axis(x.ndim, axis)
+    return min_max_(ops, x, axis=axis, keep_cupy_as_array=keep_cupy_as_array)
+
+
+@singledispatch
+def min_max_(
+    op: MinMaxOps,
+    x: CpuArray | GpuArray | DiskArray | types.DaskArray,
+    /,
+    *,
+    axis: Literal[0, 1, None] = None,
+    keep_cupy_as_array: bool = False,
+) -> NDArray[Any] | np.number[Any] | types.CupyArray | types.DaskArray:
+    del keep_cupy_as_array
+    if TYPE_CHECKING:
+        # these are never passed to this fallback function, but `singledispatch` wants them
+        assert not isinstance(x, types.CSBase | types.DaskArray | types.CupyArray | types.CupyCSMatrix)
+        # np supports these, but doesn’t know it. (TODO: test cupy)
+        assert not isinstance(x, types.ZarrArray | types.H5Dataset)
+    return cast("NDArray[Any] | np.number[Any]", getattr(np, op)(x, axis=axis))
+
+
+@min_max_.register(types.CupyArray | types.CupyCSMatrix)
+def _min_max_cupy(
+    op: MinMaxOps,
+    x: GpuArray,
+    /,
+    *,
+    axis: Literal[0, 1, None] = None,
+    keep_cupy_as_array: bool = False,
+) -> types.CupyArray | np.number[Any]:
+    arr = cast("types.CupyArray", getattr(np, op)(x, axis=axis))
+    return cast("np.number[Any]", arr.get()[()]) if not keep_cupy_as_array and axis is None else arr.squeeze()
+
+
+@min_max_.register(types.CSBase)
+def _min_max_cs(
+    op: MinMaxOps,
+    x: types.CSBase,
+    /,
+    *,
+    axis: Literal[0, 1, None] = None,
+    keep_cupy_as_array: bool = False,
+) -> NDArray[Any] | np.number[Any]:
+    del keep_cupy_as_array
+    import scipy.sparse as sp
+
+    if isinstance(x, types.CSMatrix):
+        x = sp.csr_array(x) if x.format == "csr" else sp.csc_array(x)
+
+    if axis is None:
+        return cast("np.number[Any]", getattr(sp, op)(x))
+    return cast("NDArray[Any] | np.number[Any]", getattr(sp, op)(x, axis=axis))
+
+
+@min_max_.register(types.DaskArray)
+def _min_max_dask(
+    op: MinMaxOps,
+    x: types.DaskArray,
+    /,
+    *,
+    axis: Literal[0, 1, None] = None,
+    keep_cupy_as_array: bool = False,
+) -> types.DaskArray:
+    import dask.array as da
+
+    if isinstance(x._meta, np.matrix):  # pragma: no cover  # noqa: SLF001
+        msg = "sum/max/min does not support numpy matrices"
+        raise TypeError(msg)
+
+    rv = da.reduction(
+        x,
+        partial(min_max_dask_inner, op),  # type: ignore[arg-type]
+        partial(min_max_dask_inner, op),  # pyright: ignore[reportArgumentType]
+        axis=axis,
+        meta=np.array([], dtype=x.dtype),
+    )
+
+    if axis is not None or (
+        isinstance(rv._meta, types.CupyArray)  # noqa: SLF001
+        and keep_cupy_as_array
+    ):
+        return rv
+
+    def to_scalar(a: types.CupyArray | NDArray[Any]) -> np.number[Any]:
+        if isinstance(a, types.CupyArray):
+            a = a.get()
+        return a.reshape(())[()]  # type: ignore[return-value]
+
+    return rv.map_blocks(to_scalar, meta=x.dtype.type(0))  # type: ignore[arg-type]
+
+
+def min_max_dask_inner(
+    op: MinMaxOps,
+    a: CpuArray | GpuArray,
+    /,
+    *,
+    axis: ComplexAxis = None,
+    keepdims: bool = False,
+) -> NDArray[Any] | types.CupyArray:
+    axis = normalize_axis(axis, a.ndim)
+    rv = min_max(op, a, axis=axis, keep_cupy_as_array=True)  # type: ignore[misc,arg-type]
+    shape = get_shape(rv, axis=axis, keepdims=keepdims)
+    return cast("NDArray[Any] | types.CupyArray", rv.reshape(shape))
+
+
+def normalize_axis(axis: ComplexAxis, ndim: int) -> Literal[0, 1, None]:
+    """Adapt `axis` parameter passed by Dask to what we support."""
+    match axis:
+        case int() | None:
+            pass
+        case (0 | 1,):
+            axis = axis[0]
+        case (0, 1) | (1, 0):
+            axis = None
+        case _:  # pragma: no cover
+            raise AxisError(axis, ndim)  # type: ignore[call-overload]
+    if axis == 0 and ndim == 1:
+        return None  # dask’s aggregate doesn’t know we don’t accept `axis=0` for 1D arrays
+    return axis
+
+
+def get_shape(a: NDArray[Any] | np.number[Any] | types.CupyArray, *, axis: Literal[0, 1, None], keepdims: bool) -> tuple[int] | tuple[int, int]:
+    """Get the output shape of an axis-flattening operation."""
+    match keepdims, a.ndim:
+        case False, 0:
+            return (1,)
+        case True, 0:
+            return (1, 1)
+        case False, 1:
+            return (a.size,)
+        case True, 1:
+            assert axis is not None
+            return (1, a.size) if axis == 0 else (a.size, 1)
+    # pragma: no cover
+    msg = f"{keepdims=}, {type(a)}"
+    raise AssertionError(msg)


### PR DESCRIPTION
Hello @flying-sheep @Zethson,

As mentioned in #112, I added support for min/max, but I'm unsure about my implementation, notably regarding code quality:
- The code is highly similar to the `sum` function, but it has some minor differences due to the fact that the min/max operations don't use the `dtype` argument. I think I could potentially make a function that is generic enough to handle all these "simple" operations at once, but I'm worried it would become too abstract and complex to read/maintain. What do you think?
- Two functions (`normalize_axis` and `get_shape`) are shared for `sum` and `min/max`, so I wanted to check with you where we should move them. E.g., I can create `stats/_utils.py`?
- The docs and tests are still missing, but I want to first check with you the above point and then I'll add these

Closes #112