### PR TITLE
ci: bump codecov-action to v6 to fix signature verification

### DIFF
--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -57,7 +57,7 @@ jobs:
           # https://github.com/codecov/codecov-cli/issues/648
           coverage xml
           rm test-data/.coverage
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           name: GPU Tests
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           # https://github.com/codecov/codecov-cli/issues/648
           uvx hatch run ${{ matrix.env.name }}:coverage xml
           rm test-data/.coverage
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           name: ${{ matrix.env.name }}
           fail_ci_if_error: true


### PR DESCRIPTION
`codecov-action@v5` verifies the codecov CLI binary against Codecov's old Keybase key, which they bricked after migrating accounts. Uploads now fail with `Could not verify signature`. `@v6` (= 6.0.2) ships the updated key. Version pin bump.

Ref: https://github.com/codecov/codecov-action/issues/1956